### PR TITLE
Fix graphics view actions and enable mouse-based pan/rotate navigation

### DIFF
--- a/src/osdag_gui/ui/components/custom_3dviewer.py
+++ b/src/osdag_gui/ui/components/custom_3dviewer.py
@@ -48,10 +48,40 @@ class CustomViewer3d(qtViewer3d):
         self.mouse_press_pos = None
         self.mouse_press_time = 0
 
+        # ---------------- Navigation state ----------------
+        self.active_nav_mode = None      # NavMode.ROTATE / PAN 
+        self.is_dragging_nav = False
+        self.last_mouse_pos = None
+
+
     # ------------------------------------------------------------------
     # Mouse Move Event (FIXED)
     # ------------------------------------------------------------------
     def mouseMoveEvent(self, event):
+
+        # ---------------- NAVIGATION MOVE ----------------
+        if self.is_dragging_nav and self.active_nav_mode:
+            pixel_ratio = self.devicePixelRatioF()
+
+            x = int(event.position().x() * pixel_ratio)
+            y = int(event.position().y() * pixel_ratio)
+
+            last_x = int(self.last_mouse_pos.x() * pixel_ratio)
+            last_y = int(self.last_mouse_pos.y() * pixel_ratio)
+
+            dx = x - last_x
+            dy = y - last_y
+
+            if self.active_nav_mode == NavMode.ROTATE:
+                self.view.Rotation(x, y)
+
+            elif self.active_nav_mode == NavMode.PAN:
+                self.view.Pan(dx, -dy)
+
+            self.last_mouse_pos = event.position()
+            event.accept()
+            return
+
         if not self.context or not self.view:
             super().mouseMoveEvent(event)
             return
@@ -354,12 +384,41 @@ class CustomViewer3d(qtViewer3d):
                 self.mouse_press_pos = event.position()
                 self.mouse_press_time = QTime.currentTime().msecsSinceStartOfDay()
 
+        # ---------------- NAVIGATION START ----------------
+        if (
+            event.button() == Qt.LeftButton
+            and self.active_nav_mode
+            and not self.is_interacting_with_cube
+            and self._can_start_navigation()
+        ):
+            self.is_dragging_nav = True
+            self.last_mouse_pos = event.position()
+
+            pixel_ratio = self.devicePixelRatioF()
+            x = int(event.position().x() * pixel_ratio)
+            y = int(event.position().y() * pixel_ratio)
+
+            if self.active_nav_mode == NavMode.ROTATE:
+                self.view.StartRotation(x, y)
+
+            event.accept()
+            return
+
+
+
         super().mousePressEvent(event)
 
     # ------------------------------------------------------------------
     # Mouse Release
     # ------------------------------------------------------------------
     def mouseReleaseEvent(self, event):
+        # ---------------- NAVIGATION END ----------------
+        if self.is_dragging_nav and event.button() == Qt.LeftButton:
+            self.is_dragging_nav = False
+            self.last_mouse_pos = None
+            event.accept()
+            return
+
         if self.is_interacting_with_cube:
             current_time = QTime.currentTime().msecsSinceStartOfDay()
             dt = current_time - self.mouse_press_time
@@ -380,3 +439,22 @@ class CustomViewer3d(qtViewer3d):
         QApplication.restoreOverrideCursor()
         self.releaseMouse()
         super().mouseReleaseEvent(event)
+
+    def set_navigation_mode(self, mode):
+        """
+        mode: NavMode.ROTATE | NavMode.PAN | None
+        """
+        self.active_nav_mode = mode
+
+    def _can_start_navigation(self):
+        if not self.context.HasDetected():
+            return False
+        if self.context.DetectedInteractive() == self.view_cube:
+            return False
+        return True
+
+
+
+class NavMode:
+    ROTATE = "ROTATE"
+    PAN = "PAN"

--- a/src/osdag_gui/ui/windows/template_page.py
+++ b/src/osdag_gui/ui/windows/template_page.py
@@ -30,6 +30,9 @@ from osdag_gui.data.database.database_config import *
 
 from osdag_gui.__config__ import CAD_BACKEND
 
+from osdag_gui.ui.components.custom_3dviewer import NavMode
+
+
 class CustomWindow(QWidget):
     openNewTab = Signal(str)
     downloadDatabase = Signal(str, str)
@@ -460,12 +463,11 @@ class CustomWindow(QWidget):
             print(f"Error setting initial view: {e}")
     
     def fit_all(self):
-        """Fit all objects in the view"""
         if not self._is_display_ready():
             return
         try:
-            self.display.View.SetProj(1, -1, 1)
             self.display.FitAll()
+            self.display.View.Redraw()
         except Exception as e:
             print(f"[WARNING] fit_all failed: {e}")
         
@@ -1081,15 +1083,22 @@ class CustomWindow(QWidget):
                 dialogType=MessageBoxType.Warning
             ).exec()   
 
-    # To change mode to Pan/Rotate using keyboard keys
+    # To change mode to Pan/Rotate 
     def assign_display_mode(self, mode):
         self.cad_widget.setFocus()
+
         if mode == 'Pan':
             self.display_mode = 'Pan'
+            self.cad_widget.set_navigation_mode(NavMode.PAN)
+
         elif mode == 'Rotate':
             self.display_mode = 'Rotate'
+            self.cad_widget.set_navigation_mode(NavMode.ROTATE)
+
         else:
             self.display_mode = 'Normal'
+            self.cad_widget.set_navigation_mode(None)
+
 
     def Pan_Rotate_model(self, direction):
 


### PR DESCRIPTION
This PR fixes previously non-working graphics view actions (front/top/side)
and resolves pan and rotate options from the Graphics menu by enabling
proper mode-based mouse navigation in the CAD viewer.

- Graphics menu view actions (front/top/side) now work correctly
- Pan and rotate options from the Graphics menu are now functional
- Mouse pan and rotate behave as expected based on the selected mode
- ViewCube and hover interactions remain unaffected
