### PR TITLE
Report Changes

### DIFF
--- a/src/osdag_core/Common.py
+++ b/src/osdag_core/Common.py
@@ -1607,7 +1607,7 @@ KEY_DISP_FLANGE_T = 'Flange Thickness, T (mm)*'
 KEY_DISP_WEB_HEIGHT = 'Web Height, D (mm*)'
 KEY_DISP_WEB_T = 'Web Thickness, t (mm)*'
 KEY_DISP_FLANGE_S = 'Flange Slope, α (deg.)*'
-KEY_DISP_FLANGE_S_REPORT = 'Flange Slope'
+KEY_DISP_FLANGE_S_REPORT = 'Flange Slope ($\\alpha$)'
 KEY_DISP_ROOT_R = 'Root Radius, R1 (mm)*'
 KEY_DISP_TOE_R = 'Toe Radius, R2 (mm)*'
 KEY_DISP_TYPE = 'Type'
@@ -1651,8 +1651,8 @@ KEY_DISP_BASE_PLATE_FU = 'Ultimate Strength, Fu (MPa)'
 KEY_DSIP_BASE_PLATE_FY = 'Yield Strength , Fy (MPa)'
 KEY_DISP_ST_SK_FU = 'Ultimate Strength, Fu (MPa)'
 KEY_DSIP_ST_SK_FY = 'Yield Strength , Fy (MPa)'
-KEY_DISP_ULTIMATE_STRENGTH_REPORT = 'Ultimate Strength, $F_u$ (MPa)'
-KEY_DISP_YIELD_STRENGTH_REPORT = 'Yield Strength, $F_y$ (MPa)'
+KEY_DISP_ULTIMATE_STRENGTH_REPORT = 'Ultimate Strength, $f_u$ (MPa)'
+KEY_DISP_YIELD_STRENGTH_REPORT = 'Yield Strength, $f_y$ (MPa)'
 
 # Common keys for design report
 
@@ -1689,7 +1689,7 @@ KEY_REPORT_NB = 'Nominal bore, NB (mm)'
 KEY_REPORT_OD = 'Out diameter, OD (mm)'
 
 # Design cheks
-KEY_REPORT_DIAMETER = 'Diameter $(mm)$'
+KEY_REPORT_DIAMETER = 'Diameter (mm)'
 KEY_REPORT_BOLT_NOS = 'Number of Bolts'
 KEY_REPORT_PROPERTY_CLASS = 'Property Class'
 KEY_REPORT_MIN_END = 'Min. End Distance $(mm)$'

--- a/src/osdag_core/design_report/reportGenerator_latex.py
+++ b/src/osdag_core/design_report/reportGenerator_latex.py
@@ -464,7 +464,7 @@ class CreateLatex(Document):
             view_topimg_path = rel_path + Disp_top_image
             view_sideimg_path = rel_path + Disp_side_image
             view_frontimg_path = rel_path + Disp_front_image
-            with doc.create(Section('3D Views')):
+            with doc.create(Section('Views')):
                 with doc.create(Tabularx(r'|>{\centering}X|>{\centering\arraybackslash}X|', row_height=1.1)) as table:
                     view_3dimg_path = rel_path + Disp_3d_image
                     view_topimg_path = rel_path + Disp_top_image
@@ -493,7 +493,7 @@ class CreateLatex(Document):
             view_topimg_path = imgpath_broken
             view_sideimg_path = imgpath_broken
             view_frontimg_path = imgpath_broken
-            with doc.create(Section('3D Views')):
+            with doc.create(Section('Views')):
                 with doc.create(Tabularx(r'|>{\centering}X|>{\centering\arraybackslash}X|', row_height=1.1)) as table:
                     view_3dimg_path = imgpath_broken
                     view_topimg_path = imgpath_broken
@@ -522,6 +522,15 @@ class CreateLatex(Document):
                 else:
                     continue
                 doc.append(TextColor(colour,'\n'+msg))
+        
+        doc.append(pyl.Command('vspace', arguments='10mm'))
+        with doc.create(Tabularx('|X|', row_height=1.5)) as table:
+            table.add_hline()
+            table.add_row((MultiColumn(1, align='|c|', data=bold('Note')),), color='OsdagGreen')
+            table.add_hline()
+            table.add_row([NoEscape(r'The sharing of unabridged Osdag design reports is encouraged between the designer and the reviewer for clarity (on code compliance) and openness. The output from Osdag shall be owned by the individual structural designer, and the designer also remains responsible for the final design submitted to the client, along with associated documents.')])
+            table.add_hline()
+
         try:
             latex_executable = get_latex_executable()
             doc.generate_pdf(filename, compiler=latex_executable, clean_tex = False)


### PR DESCRIPTION
Changes made -
1. Added Note: The sharing of unabridged Osdag design reports is encouraged between the designer and the reviewer for clarity (on code compliance) and openness. The output from Osdag shall be owned by the individual structural designer, and the designer also remains responsible for the final design submitted to the client, along with associated documents.
2. Implemented this change - Fu & Fy = "F" should be "f"
3. Added alpha symbol in Flange Slope
4. Corrected use of \varepsilon instead of \epsilon 2.1 in base plate report
5. Removed italics part in Diameter $$(mm)$$
